### PR TITLE
add genre data object

### DIFF
--- a/src/data/genres.json
+++ b/src/data/genres.json
@@ -1,0 +1,231 @@
+{
+  "status": "OK",
+  "copyright": "Copyright (c) 2018 The New York Times Company.  All Rights Reserved.",
+  "num_results": 28,
+  "results": [
+    {
+      "list_name": "Hardcover Fiction",
+      "display_name": "Hardcover Fiction",
+      "list_name_encoded": "hardcover-fiction",
+      "oldest_published_date": "2008-06-08",
+      "newest_published_date": "2018-08-19",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Hardcover Nonfiction",
+      "display_name": "Hardcover Nonfiction",
+      "list_name_encoded": "hardcover-nonfiction",
+      "oldest_published_date": "2008-06-08",
+      "newest_published_date": "2018-08-19",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Mass Market Paperback",
+      "display_name": "Paperback Mass-Market Fiction",
+      "list_name_encoded": "mass-market-paperback",
+      "oldest_published_date": "2008-06-08",
+      "newest_published_date": "2017-01-29",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Paperback Nonfiction",
+      "display_name": "Paperback Nonfiction",
+      "list_name_encoded": "paperback-nonfiction",
+      "oldest_published_date": "2008-06-08",
+      "newest_published_date": "2018-08-19",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "E-Book Fiction",
+      "display_name": "E-Book Fiction",
+      "list_name_encoded": "e-book-fiction",
+      "oldest_published_date": "2011-02-13",
+      "newest_published_date": "2017-01-29",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "E-Book Nonfiction",
+      "display_name": "E-Book Nonfiction",
+      "list_name_encoded": "e-book-nonfiction",
+      "oldest_published_date": "2011-02-13",
+      "newest_published_date": "2017-01-29",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Hardcover Advice",
+      "display_name": "Hardcover Advice & Misc.",
+      "list_name_encoded": "hardcover-advice",
+      "oldest_published_date": "2008-06-08",
+      "newest_published_date": "2013-04-21",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Paperback Advice",
+      "display_name": "Paperback Advice Misc.",
+      "list_name_encoded": "paperback-advice",
+      "oldest_published_date": "2008-06-08",
+      "newest_published_date": "2013-04-21",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Advice How-To and Miscellaneous",
+      "display_name": "Advice, How-To & Miscellaneous",
+      "list_name_encoded": "advice-how-to-and-miscellaneous",
+      "oldest_published_date": "2013-04-28",
+      "newest_published_date": "2018-08-19",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Paperback Books",
+      "display_name": "Children’s Paperback Books",
+      "list_name_encoded": "paperback-books",
+      "oldest_published_date": "2008-06-08",
+      "newest_published_date": "2012-12-09",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Young Adult",
+      "display_name": "Young Adult",
+      "list_name_encoded": "young-adult",
+      "oldest_published_date": "2012-12-16",
+      "newest_published_date": "2015-08-23",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Young Adult E-Book",
+      "display_name": "Young Adult E-Book",
+      "list_name_encoded": "young-adult-e-book",
+      "oldest_published_date": "2015-08-30",
+      "newest_published_date": "2017-01-29",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Young Adult Hardcover",
+      "display_name": "Young Adult Hardcover",
+      "list_name_encoded": "young-adult-hardcover",
+      "oldest_published_date": "2015-08-30",
+      "newest_published_date": "2018-08-19",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Young Adult Paperback",
+      "display_name": "Young Adult Paperback",
+      "list_name_encoded": "young-adult-paperback",
+      "oldest_published_date": "2015-08-30",
+      "newest_published_date": "2017-01-29",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Hardcover Graphic Books",
+      "display_name": "Hardcover Graphic Books",
+      "list_name_encoded": "hardcover-graphic-books",
+      "oldest_published_date": "2009-03-15",
+      "newest_published_date": "2017-01-29",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Paperback Graphic Books",
+      "display_name": "Paperback Graphic Books",
+      "list_name_encoded": "paperback-graphic-books",
+      "oldest_published_date": "2009-03-15",
+      "newest_published_date": "2017-01-29",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Manga",
+      "display_name": "Manga",
+      "list_name_encoded": "manga",
+      "oldest_published_date": "2009-03-15",
+      "newest_published_date": "2017-01-29",
+      "updated": "WEEKLY"
+    },
+    {
+      "list_name": "Crime and Punishment",
+      "display_name": "Crime and Punishment",
+      "list_name_encoded": "crime-and-punishment",
+      "oldest_published_date": "2014-10-12",
+      "newest_published_date": "2017-01-15",
+      "updated": "MONTHLY"
+    },
+    {
+      "list_name": "Food and Fitness",
+      "display_name": "Food and Diet",
+      "list_name_encoded": "food-and-fitness",
+      "oldest_published_date": "2013-09-01",
+      "newest_published_date": "2017-01-15",
+      "updated": "MONTHLY"
+    },
+    {
+      "list_name": "Health",
+      "display_name": "Health",
+      "list_name_encoded": "health",
+      "oldest_published_date": "2014-10-12",
+      "newest_published_date": "2017-01-15",
+      "updated": "MONTHLY"
+    },
+    {
+      "list_name": "Humor",
+      "display_name": "Humor",
+      "list_name_encoded": "humor",
+      "oldest_published_date": "2014-09-07",
+      "newest_published_date": "2017-01-15",
+      "updated": "MONTHLY"
+    },
+    {
+      "list_name": "Relationships",
+      "display_name": "Love and Relationships",
+      "list_name_encoded": "relationships",
+      "oldest_published_date": "2014-09-07",
+      "newest_published_date": "2017-01-15",
+      "updated": "MONTHLY"
+    },
+    {
+      "list_name": "Family",
+      "display_name": "Parenthood and Family",
+      "list_name_encoded": "family",
+      "oldest_published_date": "2014-09-07",
+      "newest_published_date": "2017-01-15",
+      "updated": "MONTHLY"
+    },
+    {
+      "list_name": "Hardcover Political Books",
+      "display_name": "Politics and American History",
+      "list_name_encoded": "hardcover-political-books",
+      "oldest_published_date": "2011-07-03",
+      "newest_published_date": "2017-01-15",
+      "updated": "MONTHLY"
+    },
+    {
+      "list_name": "Religion Spirituality and Faith",
+      "display_name": "Religion, Spirituality and Faith",
+      "list_name_encoded": "religion-spirituality-and-faith",
+      "oldest_published_date": "2014-09-07",
+      "newest_published_date": "2017-01-15",
+      "updated": "MONTHLY"
+    },
+    {
+      "list_name": "Science",
+      "display_name": "Science",
+      "list_name_encoded": "science",
+      "oldest_published_date": "2013-04-14",
+      "newest_published_date": "2018-08-12",
+      "updated": "MONTHLY"
+    },
+    {
+      "list_name": "Sports",
+      "display_name": "Sports and Fitness",
+      "list_name_encoded": "sports",
+      "oldest_published_date": "2014-03-02",
+      "newest_published_date": "2018-08-12",
+      "updated": "MONTHLY"
+    },
+    {
+      "list_name": "Travel",
+      "display_name": "Travel",
+      "list_name_encoded": "travel",
+      "oldest_published_date": "2014-09-07",
+      "newest_published_date": "2017-01-15",
+      "updated": "MONTHLY"
+    }
+  ]
+}


### PR DESCRIPTION
A slightly modified version of the response to NYT's 'list-name' endpoint which returns all the genres and the list name to query for book data